### PR TITLE
Improve README instructions for dataset download and HPC usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,20 @@ git clone https://github.com/jan3zk/tomato_segmentation.git
 cd tomato_segmentation/
 ```
 
-## Dataset Structure
-The dataset can be downloaded from [this link](https://unilj-my.sharepoint.com/:u:/g/personal/mivanovska_fe1_uni-lj_si/EUrSvUOGv6dBnlaJyFqVx5MB6SEV2NXf11uEgnwvX3UVFQ?e=SJcZls).
+## Dataset
+Download the dataset using [gdown](https://github.com/wkentaro/gdown):
+
+```bash
+gdown --id 1K5Zo47YIddzO3OnLgOJJbQig8TC_uSjb
+```
+
+If `gdown` is not installed you can add it with:
+
+```bash
+pip install --user gdown
+# or using conda
+conda install -c conda-forge gdown
+```
 
 The dataset follows the structure described below:
 
@@ -36,7 +48,7 @@ laboro_tomato/
 └── annotations.json            # Bounding box and ripeness labels
 ```
 
-## Training
+## Running in batch mode on HPC
 
 Submit the training job:
 ```bash
@@ -48,8 +60,6 @@ The training script:
 - Trains the U-Net model.
 - Saves the best model checkpoint in the `output_<timestamp>/checkpoints` directory.
 
-## Testing
-
 Submit the testing job with the model checkpoint path:
 ```bash
 sbatch test.sh output_<timestamp>/checkpoints/best_model.pt
@@ -59,6 +69,10 @@ The testing script:
 - Loads the trained model.
 - Evaluates on the test dataset.
 - Saves predictions and evaluation results in a `test_results_<timestamp>` directory.
+
+## Running in interactive mode on HPC
+
+For interactive sessions we recommend installing [uhpc-tools](https://github.com/jpers1/uhpc-tools). After installation you can request an interactive GPU session and run `python train.py` or `python test.py` directly.
 
 ## Model Architecture
 The U-Net model includes:


### PR DESCRIPTION
## Summary
- download dataset via `gdown` instead of link
- show how to install `gdown`
- organize HPC instructions under **Running in batch mode on HPC**
- add new **Running in interactive mode on HPC** section pointing to uhpc-tools

## Testing
- `python -m py_compile *.py`